### PR TITLE
Add prototype VC pitch practice service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,33 @@
 # Practice Pitch
+
+This project is a prototype service that allows startup founders to practice their pitch with an AI powered investor.
+
+## Repository layout
+
+- `backend/` – FastAPI application handling submissions and scheduling.
+- `frontend/` – React + TypeScript client for the website and form.
+
+## Running the backend
+
+Python 3.11 is required. Install dependencies:
+
+```bash
+pip install fastapi uvicorn requests pydantic beautifulsoup4
+```
+
+Run the development server:
+
+```bash
+uvicorn backend.app:app --reload
+```
+
+## Running the frontend
+
+The frontend uses Vite. From the `frontend` directory run:
+
+```bash
+npm install
+npm run dev
+```
+
+Open http://localhost:5173 to view the site.

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,0 +1,55 @@
+from fastapi import FastAPI, BackgroundTasks
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel, EmailStr, HttpUrl
+from typing import Optional
+import requests
+from bs4 import BeautifulSoup
+import json
+
+app = FastAPI()
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+class Application(BaseModel):
+    company_name: str
+    website: HttpUrl
+    linkedin: HttpUrl
+    pitch_deck: HttpUrl
+    github: Optional[HttpUrl] = None
+    email: EmailStr
+    meeting_time: str
+
+@app.post("/api/apply")
+async def apply(application: Application, background_tasks: BackgroundTasks):
+    with open("applications.json", "a") as f:
+        f.write(json.dumps(application.model_dump()) + "\n")
+    background_tasks.add_task(crawl_company, application)
+    zoom_link = create_zoom_meeting(application)
+    send_invite_email(application.email, zoom_link, application.meeting_time)
+    return {"zoom": zoom_link}
+
+def crawl_company(app_data: Application):
+    info = {}
+    try:
+        resp = requests.get(app_data.website)
+        soup = BeautifulSoup(resp.text, "html.parser")
+        info["title"] = soup.title.string if soup.title else ""
+    except Exception as e:
+        info["error"] = str(e)
+    with open(f"crawl_{app_data.company_name}.json", "w") as f:
+        json.dump(info, f)
+
+def create_zoom_meeting(app_data: Application) -> str:
+    """Placeholder Zoom meeting creation"""
+    # TODO: Integrate with Zoom's API
+    return "https://example.com/zoom-meeting"
+
+def send_invite_email(to_email: str, zoom_link: str, meeting_time: str) -> None:
+    """Placeholder email sender"""
+    # TODO: use smtplib or an email service
+    print(f"Send invite to {to_email} for {meeting_time} -> {zoom_link}")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+uvicorn
+requests
+beautifulsoup4
+pydantic

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "practicepitch-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "typescript": "^5.2.0",
+    "vite": "^5.0.0",
+    "@vitejs/plugin-react": "^5.0.0"
+  }
+}

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Practice Pitch</title>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="module" src="/src/index.tsx"></script>
+</body>
+</html>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,62 @@
+import { useState } from 'react'
+
+interface FormData {
+  company_name: string
+  website: string
+  linkedin: string
+  pitch_deck: string
+  github?: string
+  email: string
+  meeting_time: string
+}
+
+export default function App() {
+  const [form, setForm] = useState<FormData>({
+    company_name: '',
+    website: '',
+    linkedin: '',
+    pitch_deck: '',
+    github: '',
+    email: '',
+    meeting_time: ''
+  })
+  const [status, setStatus] = useState('')
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setForm({ ...form, [e.target.name]: e.target.value })
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setStatus('Submitting...')
+    const res = await fetch('http://localhost:8000/api/apply', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(form)
+    })
+    if (res.ok) {
+      const data = await res.json()
+      setStatus('Scheduled! Zoom link: ' + data.zoom)
+    } else {
+      setStatus('Error submitting form')
+    }
+  }
+
+  return (
+    <div>
+      <h1>Practice Pitch</h1>
+      <p>Fill out the form below to schedule a practice session with our VC bot.</p>
+      <form onSubmit={handleSubmit}>
+        <input name="company_name" placeholder="Company Name" value={form.company_name} onChange={handleChange} required />
+        <input name="website" placeholder="Website" value={form.website} onChange={handleChange} required />
+        <input name="linkedin" placeholder="Founders LinkedIn" value={form.linkedin} onChange={handleChange} required />
+        <input name="pitch_deck" placeholder="Pitch Deck URL" value={form.pitch_deck} onChange={handleChange} required />
+        <input name="github" placeholder="GitHub (optional)" value={form.github} onChange={handleChange} />
+        <input name="email" placeholder="Contact Email" value={form.email} onChange={handleChange} required />
+        <input name="meeting_time" placeholder="Preferred Time" value={form.meeting_time} onChange={handleChange} required />
+        <button type="submit">Schedule</button>
+      </form>
+      <p>{status}</p>
+    </div>
+  )
+}

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,0 +1,9 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App'
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+)

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "module": "ESNext",
+    "jsx": "react-jsx",
+    "strict": true,
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  root: '.',
+  server: {
+    port: 5173
+  }
+})


### PR DESCRIPTION
## Summary
- describe project in README with instructions
- add FastAPI backend for handling submissions
- add React/TypeScript frontend with simple form

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687dced728308328ad4a2f7acc3a2df7